### PR TITLE
[REFACTOR] 관측 날씨 저장 - 체감온도 공식 추가

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,3 +65,15 @@ model observed_weather {
   rain                Int?
   sensory_temperature Int?
 }
+
+model today_message {
+  id      Int    @id @default(autoincrement())
+  warning Int
+  message String @db.VarChar(255)
+}
+
+model yesterday_message {
+  id      Int    @id @default(autoincrement())
+  warning Int
+  message String @db.VarChar(255)
+}


### PR DESCRIPTION
close #30

- 관측 날씨 저장 시 체감 온도를 계산하도록 구현했습니다.
  - 여름철인 경우 -> 기온, 습도 공식 이용
  - 겨울철인데, 기온이 10도 이하, 풍속이 1.3 이상인 경우 -> 기온, 풍속 공식 이용
  - 겨울철인데, 이 외인 경우 -> 기온과 동일