### PR TITLE
[REFACTOR] 오늘 날씨 조회 데이터 추가 연결

### DIFF
--- a/src/DTO/WeatherDTO.ts
+++ b/src/DTO/WeatherDTO.ts
@@ -5,8 +5,8 @@ export interface TodayWeatherDTO {
     breakingNews: number; //! string으로 변경예정
     fineDust: number;
     ultrafineDust: number;
-    weatherImage: number;
-    weatherImageDesc: string;
+    imageTime: string;
+    imageDesc: string;
     currentTemp: number;
     minTemp: number;
     maxTemp: number;

--- a/src/DTO/WeatherDTO.ts
+++ b/src/DTO/WeatherDTO.ts
@@ -2,7 +2,7 @@ export interface TodayWeatherDTO {
     location: string;
     compareTemp: number;
     compareMessage: string;
-    breakingNews: number; //! string으로 변경예정
+    breakingNews: string;
     fineDust: number;
     ultrafineDust: number;
     imageTime: string;

--- a/src/modules/authToken.ts
+++ b/src/modules/authToken.ts
@@ -24,7 +24,7 @@ export default async (req: Request, res: Response, next: NextFunction) => {
     if (!userId) return res.status(sc.UNAUTHORIZED).send(util.fail(sc.UNAUTHORIZED, rm.TOKEN_INVALID));
 
     //? 얻어낸 userId 를 Request Body 내 userId 필드에 담고, 다음 미들웨어로 넘김( next() )
-    req.body.userId = userId;
+    req.body.user = userId;
     next();
   } catch (error) {
     console.log(error);

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -23,81 +23,32 @@ interface Weather {
 const createObserved = async () => {
   let now = moment();
   if (now.get("m") < 40) {
-    if (now.get("h") == 0) {
-      now = now.set("h", 23);
-      now = now.add(-1, "day");
-    } else now = now.add(-1, "h");
+    now = now.add(-1, "h");
   }
   const time = now.format("HH00");
   const date = now.format("YYYYMMDD");
 
-  const ultraSrtNcstUrl =
-    "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getUltraSrtNcst";
-  let queryParams =
-    "?" +
-    encodeURIComponent("serviceKey") +
-    "=" +
-    `${process.env.WEATHER_SERVICE_KEY}`; /* Service Key*/
-  queryParams +=
-    "&" + encodeURIComponent("pageNo") + "=" + encodeURIComponent("1"); /* */
-  queryParams +=
-    "&" +
-    encodeURIComponent("numOfRows") +
-    "=" +
-    encodeURIComponent("1000"); /* */
-  queryParams +=
-    "&" +
-    encodeURIComponent("dataType") +
-    "=" +
-    encodeURIComponent("JSON"); /* */
-  queryParams +=
-    "&" +
-    encodeURIComponent("base_date") +
-    "=" +
-    encodeURIComponent(date); /* */
-  queryParams +=
-    "&" +
-    encodeURIComponent("base_time") +
-    "=" +
-    encodeURIComponent(time); /* */
-  queryParams +=
-    "&" + encodeURIComponent("nx") + "=" + encodeURIComponent("60"); /* */
-  queryParams +=
-    "&" + encodeURIComponent("ny") + "=" + encodeURIComponent("127"); /* */
+  const ultraSrtNcstUrl = "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getUltraSrtNcst";
+  let queryParams = "?" + encodeURIComponent("serviceKey") + "=" + `${process.env.WEATHER_SERVICE_KEY}`; /* Service Key*/
+  queryParams += "&" + encodeURIComponent("pageNo") + "=" + encodeURIComponent("1"); /* */
+  queryParams += "&" + encodeURIComponent("numOfRows") + "=" + encodeURIComponent("1000"); /* */
+  queryParams += "&" + encodeURIComponent("dataType") + "=" + encodeURIComponent("JSON"); /* */
+  queryParams += "&" + encodeURIComponent("base_date") + "=" + encodeURIComponent(date); /* */
+  queryParams += "&" + encodeURIComponent("base_time") + "=" + encodeURIComponent(time); /* */
+  queryParams += "&" + encodeURIComponent("nx") + "=" + encodeURIComponent("60"); /* */
+  queryParams += "&" + encodeURIComponent("ny") + "=" + encodeURIComponent("127"); /* */
 
-  const dustUrl =
-    "http://apis.data.go.kr/B552584/ArpltnInforInqireSvc/getCtprvnRltmMesureDnsty";
-  let dustQueryParams =
-    "?" +
-    encodeURIComponent("serviceKey") +
-    "=" +
-    `${process.env.WEATHER_SERVICE_KEY}`; /* Service Key*/
-  dustQueryParams +=
-    "&" + encodeURIComponent("pageNo") + "=" + encodeURIComponent("1"); /* */
-  dustQueryParams +=
-    "&" +
-    encodeURIComponent("numOfRows") +
-    "=" +
-    encodeURIComponent("1000"); /* */
-  dustQueryParams +=
-    "&" +
-    encodeURIComponent("returnType") +
-    "=" +
-    encodeURIComponent("JSON"); /* */
-  dustQueryParams +=
-    "&" +
-    encodeURIComponent("sidoName") +
-    "=" +
-    encodeURIComponent("서울"); /* */
-  dustQueryParams +=
-    "&" + encodeURIComponent("ver") + "=" + encodeURIComponent("1.3"); /* */
+  const dustUrl = "http://apis.data.go.kr/B552584/ArpltnInforInqireSvc/getCtprvnRltmMesureDnsty";
+  let dustQueryParams = "?" + encodeURIComponent("serviceKey") + "=" + `${process.env.WEATHER_SERVICE_KEY}`; /* Service Key*/
+  dustQueryParams += "&" + encodeURIComponent("pageNo") + "=" + encodeURIComponent("1"); /* */
+  dustQueryParams += "&" + encodeURIComponent("numOfRows") + "=" + encodeURIComponent("1000"); /* */
+  dustQueryParams += "&" + encodeURIComponent("returnType") + "=" + encodeURIComponent("JSON"); /* */
+  dustQueryParams += "&" + encodeURIComponent("sidoName") + "=" + encodeURIComponent("서울"); /* */
+  dustQueryParams += "&" + encodeURIComponent("ver") + "=" + encodeURIComponent("1.3"); /* */
 
   let forecastNow = moment();
   if (forecastNow.get("m") < 45) {
-    if (forecastNow.get("h") == 0) {
-      forecastNow = forecastNow.set("h", 23);
-      forecastNow = forecastNow.add(-1, "day");
-    } else forecastNow = forecastNow.add(-1, "h");
+    forecastNow = forecastNow.add(-1, "h");
   }
   let forecastTime = forecastNow.format("HH00");
   const forecastDate = forecastNow.format("YYYYMMDD");
@@ -143,62 +94,127 @@ const createObserved = async () => {
 
   await axios.all([axios.get(ultraSrtNcstUrl + queryParams), axios.get(dustUrl + dustQueryParams), axios.get(ultraSrtFcstUrl + fcstQueryParams)])
     .then(axios.spread((ncstResult, dustResult, fcstResult) => {
-      const ncstJson = ncstResult.data.response.body.items.item;
-      const filtered = ncstJson.filter(filter);
-      const value = filtered.map((element: Weather) => {
-        return { category: element.category, obsrValue: element.obsrValue };
-      });
-      ultraSrtNcst = value;
+      const ncstRes = ncstResult.data.response;
+      if (ncstRes.header.resultCode == "00") {
+        const ncstData = ncstResult.data.response.body.items.item;
+        const filtered = ncstData.filter(filter);
+        const value = filtered.map((element: Weather) => {
+          return { category: element.category, obsrValue: element.obsrValue };
+        });
+        ultraSrtNcst = value;
+      }
 
-      const dustJson = dustResult.data.response.body.items;
-      const dustFiltered = dustJson.filter(dustFilter);
-      dust = {
-        pm25: dustFiltered[0].pm25Grade1h ?? dustFiltered[1].pm25Grade1h,
-        pm10: dustFiltered[0].pm10Grade1h ?? dustFiltered[1].pm25Grade1h
-      };
+      const dustRes = dustResult.data.response;
+      if (dustRes.body.totalCount != 0) {
+        const dustData = dustRes.body.items;
+        const dustFiltered = dustData.filter(dustFilter);
+        dust = {
+          pm25: dustFiltered[0].pm25Grade1h ?? dustFiltered[1].pm25Grade1h,
+          pm10: dustFiltered[0].pm10Grade1h ?? dustFiltered[1].pm25Grade1h
+        };
+      }
 
-      const fcstJson = fcstResult.data.response.body.items.item;
-      const fcstFiltered = fcstJson.filter(fcstFilter);
-      const fcstValue = fcstFiltered.map((element) => {
-        return { category: element.category, obsrValue: element.fcstValue };
-      });
-      ultraSrtFcst = fcstValue;
+      const fcstRes = fcstResult.data.response;
+      if (fcstRes.header.resultCode == "00") {
+        const fcstData = fcstRes.body.items.item;
+        const fcstFiltered = fcstData.filter(fcstFilter);
+        const fcstValue = fcstFiltered.map((element) => {
+          return { category: element.category, obsrValue: element.fcstValue };
+        });
+        ultraSrtFcst = fcstValue;
+      }
     }))
     .catch((err) => console.log(err));
 
-  if (ultraSrtNcst == undefined || dust == undefined || ultraSrtFcst == undefined) return null;
+  let temp, humidity, rain, sensTemp;
+  const past = moment().add(-1, "h")
+  const pastDate = past.format("YYYYMMDD");
+  const pastTime = past.format("HH00");
+  if (ultraSrtNcst == undefined) {
+    const past_observed = await prisma.observed_weather.findFirst({
+      where: {
+        date: pastDate,
+        time: pastTime,
+      },
+      select: {
+        temperature: true,
+        rain: true,
+        humidity: true,
+        sensory_temperature: true
+      }
+    });
+    temp = past_observed.temperature;
+    humidity = past_observed.humidity;
+    rain = past_observed.rain;
+    sensTemp = past_observed.sensory_temperature;
+  } else {
+    temp = Math.floor(+ultraSrtNcst[2].obsrValue);
+    humidity = +ultraSrtNcst[0].obsrValue;
+    rain = Math.round(+ultraSrtNcst[1].obsrValue);
+    const wind = +ultraSrtNcst[3].obsrValue;
 
-  const temp = +ultraSrtNcst[2].obsrValue;
-  const wind = +ultraSrtNcst[3].obsrValue;
-  const humidity = +ultraSrtNcst[0].obsrValue;
+    sensTemp = temp;
+    const month = moment().month() + 1;
 
-  let sensTemp = temp;
-  const month = moment().month() + 1;
+    if (month > 4 && month < 10) { //여름철
+      const tw = temp * Math.atan(0.151977 * Math.pow(humidity + 8.313659, 1 / 2)) + Math.atan(temp + humidity) - Math.atan(humidity - 1.67633) + 0.00391838 * Math.pow(humidity, 3 / 2) * Math.atan(0.023101 * humidity) - 4.686035;
+      sensTemp = -0.2442 + 0.55399 * tw + 0.45535 * temp + (-0.0022 * Math.pow(tw, 2)) + 0.00278 * tw * temp + 3.0;
+    } else if (temp <= 10 && wind >= 1.3) { //겨울철
+      sensTemp = 13.12 + 0.6215 * temp - 11.37 * Math.pow(wind, 0.16) + 0.3965 * Math.pow(wind, 0.16) * temp;
+    }
+    sensTemp = Math.floor(sensTemp);
+  }
+  if (dust == undefined) {
+    const past_dust = await prisma.observed_weather.findFirst({
+      where: {
+        date: pastDate,
+        time: pastTime,
+      },
+      select: {
+        pm10: true,
+        pm25: true,
+      },
+    });
+    dust = {
+      pm25: past_dust.pm25,
+      pm10: past_dust.pm10
+    };
+  }
 
-  if (month > 4 && month < 10) { //여름철
-    const tw = temp * Math.atan(0.151977 * Math.pow(humidity + 8.313659, 1 / 2)) + Math.atan(temp + humidity) - Math.atan(humidity - 1.67633) + 0.00391838 * Math.pow(humidity, 3 / 2) * Math.atan(0.023101 * humidity) - 4.686035;
-    sensTemp = -0.2442 + 0.55399 * tw + 0.45535 * temp + (-0.0022 * Math.pow(tw, 2)) + 0.00278 * tw * temp + 3.0;
-  } else if (temp <= 10 && wind >= 1.3) { //겨울철
-    sensTemp = 13.12 + 0.6215 * temp - 11.37 * Math.pow(wind, 0.16) + 0.3965 * Math.pow(wind, 0.16) * temp;
+  let sky, pty;
+  if (ultraSrtFcst == undefined) {
+    const past_fcst = await prisma.observed_weather.findFirst({
+      where: {
+        date: pastDate,
+        time: pastTime,
+      },
+      select: {
+        pty: true,
+        sky: true,
+      },
+    });
+    sky = past_fcst.sky;
+    pty = past_fcst.pty;
+  } else {
+    sky = +ultraSrtFcst[1].obsrValue;
+    pty = +ultraSrtFcst[0].obsrValue;
   }
 
   const data = {
     date: moment().format("YYYYMMDD"),
     time: moment().format("HH00"),
-    temperature: Math.floor(temp),
+    temperature: temp,
     humidity: humidity,
     pm25: +dust.pm25,
     pm10: +dust.pm10,
-    rain: Math.round(+ultraSrtNcst[1].obsrValue),
-    sensory_temperature: Math.floor(sensTemp),
-    sky: +ultraSrtFcst[1].obsrValue,
-    pty: +ultraSrtFcst[0].obsrValue,
+    rain: rain,
+    sensory_temperature: sensTemp,
+    sky: sky,
+    pty: pty,
   };
 
-  const result = data;
-  //const result = await prisma.observed_weather.create({ data });
-  console.log("result", result);
-
+  const result = await prisma.observed_weather.create({ data });
+  //console.log("result", result);
   return result;
 };
 

--- a/src/services/WeatherService.ts
+++ b/src/services/WeatherService.ts
@@ -71,11 +71,14 @@ const getTodayWeather = async () => {
 
     const image = (observedToday.sky != 0)? sky[observedToday.sky] : pty[observedToday.pty];
 
+    const breakingNewsArr = [ '','강풍', '호우', '한파', '건조', '폭풍해일', '풍랑', '태풍', '대설', '황사', '', '', '폭염'];
+    const breakingNews = breakingNewsArr[dailyForecast.warning] + '특보';
+
     const result: TodayWeatherDTO = {
         location: "서울, 중구 명동",
         compareTemp: observedToday.temperature - observedYesterday.temperature,
         compareMessage: compareMessage,
-        breakingNews: dailyForecast.warning, //! 특보 -> string 으로 변경
+        breakingNews: breakingNews,
         fineDust: observedToday.pm10,
         ultrafineDust: observedToday.pm25,
         imageTime: time, 


### PR DESCRIPTION
close #32

<img width="480" alt="image" src="https://user-images.githubusercontent.com/70002218/211387027-389cc147-5413-4518-8bd2-d34472ef5542.png">


- 미세먼지 통신 장애일 경우 종로구로 저장
- 관측 날씨 api(초단기실황, 미세먼지, 초단기예보) 중 일부 에러 시 
   이전 시간 데이터 가져오도록 수정
- 날씨 이미지 추가 `imageTime`, `imageDesc`
- 특보 string으로 수정 `breakingNews`
- authToken 연결... (이건 conflict 해결하다가 붙여버렸는데 수정해도 됨!!!)